### PR TITLE
add configuration option for a path to 'bundle'

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -133,6 +133,7 @@ action :create do
         :sidekiq_config => sidekiq_config,
         :working_dir => working_dir,
         :bundle_exec => new_resource.bundle_exec,
+        :bundle_cmd => new_resource.bundle_cmd,
         :rails_env => new_resource.rails_env,
         :owner => new_resource.owner,
         :group => new_resource.group

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,6 +27,7 @@ attribute :processes, :kind_of => Integer, :default => 1
 attribute :timeout, :kind_of => Integer, :default => 30
 attribute :rails_env, :kind_of => String, :default => 'production'
 attribute :bundle_exec, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :bundle_cmd, :kind_of => String, :default => 'bundle'
 attribute :logrotate, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :owner, :regex => Chef::Config[:user_valid_regex], :default => 'www-data'
 attribute :group, :regex => Chef::Config[:group_valid_regex], :default => 'www-data'

--- a/templates/default/sv-sidekiq-run.erb
+++ b/templates/default/sv-sidekiq-run.erb
@@ -13,7 +13,7 @@ cd "<%= @options[:working_dir] %>"
 
 # Start sidekiq
 <% if @options[:bundle_exec] -%>
-  exec chpst -u <%= @options[:owner] %>:<%= @options[:group] %> bundle exec sidekiq -C <%= @options[:sidekiq_config] %> -e <%= @options[:rails_env] %>
+  exec chpst -u <%= @options[:owner] %>:<%= @options[:group] %> <%= @options[:bundle_cmd] %> exec sidekiq -C <%= @options[:sidekiq_config] %> -e <%= @options[:rails_env] %>
 <% else -%>
   exec chpst -u <%= @options[:owner] %>:<%= @options[:group] %> sidekiq -C <%= @options[:sidekiq_config] %> -e <%= @options[:rails_env] %>
 <% end -%>


### PR DESCRIPTION
It is useful for rbenv-flavored setup and does not change default behaviour.  

Example:

``` ruby
sidekiq 'rm8.dev' do
  concurrency 1
  queues 'job-queue' => 2
  owner user
  group user
  rails_env environment
  bundle_cmd "/home/app/.rbenv/shims/bundle"
end
```
