### PR TITLE
Add `create_sidekiq` ChefSpec matcher for unit tests

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,5 @@
+if defined?(ChefSpec)
+  def create_sidekiq(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:sidekiq, :create, resource_name)
+  end
+end


### PR DESCRIPTION
It is possible to use the following syntax in specs:

```
expect(chef_run).to create_sidekiq("foo").
  with(concurrency: 8,
       processes:   1,
       ...)
```
