### PR TITLE
Add support for custom env files

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -136,7 +136,8 @@ action :create do
         :bundle_command => new_resource.bundle_command,
         :rails_env => new_resource.rails_env,
         :owner => new_resource.owner,
-        :group => new_resource.group
+        :group => new_resource.group,
+        :custom_env_files => new_resource.custom_env_files
       )
     end
   end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -37,6 +37,7 @@ attribute :sidekiq_dir, :kind_of => [String, NilClass], :default => nil
 attribute :sidekiq_config, :kind_of => [String, NilClass], :default => nil
 attribute :pidfile, :kind_of => [String, NilClass], :default => nil
 attribute :logfile, :kind_of => [String, NilClass], :default => nil
+attribute :custom_env_files, :kind_of => [Array], :default => []
 
 def initialize(*args)
   super

--- a/templates/default/sv-sidekiq-run.erb
+++ b/templates/default/sv-sidekiq-run.erb
@@ -5,6 +5,10 @@
 exec 2>&1
 
 . /etc/profile
+<% @options[:custom_env_files].each do |file| %>
+. <%= file %>
+<% end %>
+
 
 # Remove pidfile just incase it wasn't properly removed on shutdown.
 rm -f "<%= @options[:pidfile] %>"


### PR DESCRIPTION
Hi there,

I need to load additional environment variables for sidekiq worker. They are defined in the file as `export KEY=VALUE`s. I would like to load that file while chef run.

Here is the solution where you are able to specify an array of file to load before running sidekiq worker.
